### PR TITLE
Fix .gitmodules URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "SolidPython"]
 	path = SolidPython
-	url = git://github.com/SolidCode/SolidPython.git
+	url = https://github.com/SolidCode/SolidPython.git
 [submodule "ThingDoc"]
 	path = ThingDoc
-	url = git://github.com/SolidCode/ThingDoc.git
+	url = https://github.com/SolidCode/ThingDoc.git


### PR DESCRIPTION
This should fix my error "the submodule registered for `./SolidPython` could not be cloned. Make sure it's using https:// and that it's a public repo. For more information, see https://help.github.com/articles/page-build-failed-invalid-submodule.
" when I upload a new version on poppy-ergo-jr gh-ages
